### PR TITLE
Add support for user-defined generic types for schedule arguments

### DIFF
--- a/src/wally.toml
+++ b/src/wally.toml
@@ -1,6 +1,6 @@
 [package]
 name = "data-oriented-house/sandwich"
-version = "2.2.1"
+version = "2.2.2"
 registry = "https://github.com/UpliftGames/wally-index"
 licence = "MIT"
 authors = ["Sona"]


### PR DESCRIPTION
Currently, Sandwich does not offer any mechanisms for inferring the arguments of functions such as `Schedule.job`. Being a type-crazed maniac, I decided to add one.

I followed the same philosophy as sleitnick's Signal implementation, inferring types where possible, but allowing them to be specified via typecast to the `Schedule` type. For example:
```lua
local LoadService = {
	playerRequestedLoad = Sandwich.schedule() :: Sandwich.Schedule<Player>,
}
```

I also edited the documentation comments to match the new type generics.

As a side note, I have removed the type errors in `Sandwich.tick` caused by providing generic arguments to the `RBXScriptSignal` type:
![image](https://github.com/Data-Oriented-House/Sandwich/assets/94771866/5666ca58-4d02-4547-9d2a-9688ffff8377)
and Roblox not knowing how to infer the result of `event:Connect`:
![image](https://github.com/Data-Oriented-House/Sandwich/assets/94771866/723ef57d-2863-48cb-925b-a48e468d3377)
I only modified this function to remove the type errors, as the types are currently unhelpful. I would approach solving the problem by opting not to depend on a faithful RBXScriptSignal implementation, simplifying the function to just add a cooldown to the passed callback, which the user can then feed to their event. However, I would prefer not to add a breaking change to this PR.